### PR TITLE
Add "org.embulk:embulk-standards" to dependencies instead of import jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile fileTree(dir: 'libs', include: '*.jar')
     compile "org.embulk:embulk-core:0.8.22"
+    compile "org.embulk:embulk-standards:0.8.22"
     compile "com.opencsv:opencsv:3.9"
     provided "org.embulk:embulk-core:0.8.22"
     testCompile "junit:junit:4.+"


### PR DESCRIPTION
Hi.

I added `org.embulk:embulk-standards` to build.gradle#dependencies instead of import libs/embulk-0.8.22.jar.
I think this change will decrease gem file size.
I'm sorry but I've not checked deeply. This change won't works?