### PR TITLE
Fix code format that were warned by `./gradlew checkstyle`

### DIFF
--- a/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
@@ -136,7 +136,8 @@ public class CsvGuessableParserPlugin
             if (task.getHeaderLine().isPresent()) {
                 // TODO: use 'columns' as hints for guess
                 throw new ConfigException("embulk-parsre-csv_gussable will use 'columnes' as hints for guess as hints for guess. Please delete 'columnes' now.");
-            } else { /* guess from header */
+            }
+            else { /* guess from header */
                 int schemaLine = task.getSchemaLine();
                 task.setSkipHeaderLines(schemaLine); // TODO: use 'skip_header_line'
 
@@ -146,7 +147,8 @@ public class CsvGuessableParserPlugin
                 log.debug(columns.toString());
                 schemaConfig = new SchemaConfig(columns);
             }
-        } else { /* embulk-parser-csv embulk */
+        }
+        else { /* embulk-parser-csv embulk */
             // backward compatibility
             if (task.getHeaderLine().isPresent()) {
                 if (task.getSkipHeaderLines() > 0) {
@@ -154,7 +156,8 @@ public class CsvGuessableParserPlugin
                 }
                 if (task.getHeaderLine().get()) {
                     task.setSkipHeaderLines(1);
-                } else {
+                }
+                else {
                     task.setSkipHeaderLines(0);
                 }
             }
@@ -204,7 +207,8 @@ public class CsvGuessableParserPlugin
                                 String v = nextColumn();
                                 if (v == null) {
                                     pageBuilder.setNull(column);
-                                } else {
+                                }
+                                else {
                                     pageBuilder.setBoolean(column, TRUE_STRINGS.contains(v));
                                 }
                             }
@@ -214,10 +218,12 @@ public class CsvGuessableParserPlugin
                                 String v = nextColumn();
                                 if (v == null) {
                                     pageBuilder.setNull(column);
-                                } else {
+                                }
+                                else {
                                     try {
                                         pageBuilder.setLong(column, Long.parseLong(v));
-                                    } catch (NumberFormatException e) {
+                                    }
+                                    catch (NumberFormatException e) {
                                         // TODO support default value
                                         throw new CsvRecordValidateException(e);
                                     }
@@ -229,10 +235,12 @@ public class CsvGuessableParserPlugin
                                 String v = nextColumn();
                                 if (v == null) {
                                     pageBuilder.setNull(column);
-                                } else {
+                                }
+                                else {
                                     try {
                                         pageBuilder.setDouble(column, Double.parseDouble(v));
-                                    } catch (NumberFormatException e) {
+                                    }
+                                    catch (NumberFormatException e) {
                                         // TODO support default value
                                         throw new CsvRecordValidateException(e);
                                     }
@@ -244,7 +252,8 @@ public class CsvGuessableParserPlugin
                                 String v = nextColumn();
                                 if (v == null) {
                                     pageBuilder.setNull(column);
-                                } else {
+                                }
+                                else {
                                     pageBuilder.setString(column, v);
                                 }
                             }
@@ -254,10 +263,12 @@ public class CsvGuessableParserPlugin
                                 String v = nextColumn();
                                 if (v == null) {
                                     pageBuilder.setNull(column);
-                                } else {
+                                }
+                                else {
                                     try {
 //                                        pageBuilder.setTimestamp(column, timestampParsers[column.getIndex()].parse(v));
-                                    } catch (TimestampParseException e) {
+                                    }
+                                    catch (TimestampParseException e) {
                                         // TODO support default value
                                         throw new CsvRecordValidateException(e);
                                     }
@@ -269,10 +280,12 @@ public class CsvGuessableParserPlugin
                                 String v = nextColumn();
                                 if (v == null) {
                                     pageBuilder.setNull(column);
-                                } else {
+                                }
+                                else {
                                     try {
                                         pageBuilder.setJson(column, jsonParser.parse(v));
-                                    } catch (JsonParseException e) {
+                                    }
+                                    catch (JsonParseException e) {
                                         // TODO support default value
                                         throw new CsvRecordValidateException(e);
                                     }
@@ -291,19 +304,21 @@ public class CsvGuessableParserPlugin
 
                         try {
                             hasNextRecord = tokenizer.nextRecord();
-                        } catch (CsvTokenizer.TooManyColumnsException ex) {
+                        }
+                        catch (CsvTokenizer.TooManyColumnsException ex) {
                             if (allowExtraColumns) {
                                 String tooManyColumnsLine = tokenizer.skipCurrentLine();
                                 // TODO warning
                                 hasNextRecord = tokenizer.nextRecord();
-                            } else {
+                            }
+                            else {
                                 // this line will be skipped at the following catch section
                                 throw ex;
                             }
                         }
                         pageBuilder.addRecord();
-
-                    } catch (CsvTokenizer.InvalidFormatException | CsvTokenizer.InvalidValueException | CsvRecordValidateException e) {
+                    }
+                    catch (CsvTokenizer.InvalidFormatException | CsvTokenizer.InvalidValueException | CsvRecordValidateException e) {
                         String skippedLine = tokenizer.skipCurrentLine();
                         long lineNumber = tokenizer.getCurrentLineNumber();
                         if (stopOnInvalidRecord) {
@@ -334,14 +349,15 @@ public class CsvGuessableParserPlugin
         }
     }
 
-    private String readHeader(Path path, int schemaLine) {
+    private String readHeader(Path path, int schemaLine)
+    {
         if (schemaLine <= 0) {
             throw new ConfigException("'schemaLine' must be set '> 0'");
         }
 
         String line = null;
         try (BufferedReader br = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
-            for (int i=1; i <= schemaLine; ++i) {
+            for (int i = 1; i <= schemaLine; ++i) {
                 line = br.readLine();
                 if (line == null) {
                     throw new ConfigException("not found 'schema_line' in 'schema_file'");
@@ -353,13 +369,14 @@ public class CsvGuessableParserPlugin
         return line;
     }
 
-    private ArrayList<ColumnConfig> newColumns(String header, ConfigSource config) {
-        ArrayList columns = new ArrayList<ArrayList>(); 
+    private ArrayList<ColumnConfig> newColumns(String header, ConfigSource config)
+    {
+        ArrayList columns = new ArrayList<ArrayList>();
         PluginTask task = config.loadConfig(PluginTask.class);
 
         try (CSVReader reader = new CSVReader(new StringReader(header))) {
             String[] csv = reader.readNext();
-            for (String column: csv) {
+            for (String column : csv) {
                 columns.add(new ColumnConfig(column, Types.STRING, config));
             }
         } catch (IOException e) {

--- a/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
@@ -202,6 +202,7 @@ public class CsvGuessableParserPlugin
 
                     try {
                         schema.visitColumns(new ColumnVisitor() {
+                            @Override
                             public void booleanColumn(Column column)
                             {
                                 String v = nextColumn();
@@ -213,6 +214,7 @@ public class CsvGuessableParserPlugin
                                 }
                             }
 
+                            @Override
                             public void longColumn(Column column)
                             {
                                 String v = nextColumn();
@@ -230,6 +232,7 @@ public class CsvGuessableParserPlugin
                                 }
                             }
 
+                            @Override
                             public void doubleColumn(Column column)
                             {
                                 String v = nextColumn();
@@ -247,6 +250,7 @@ public class CsvGuessableParserPlugin
                                 }
                             }
 
+                            @Override
                             public void stringColumn(Column column)
                             {
                                 String v = nextColumn();
@@ -258,6 +262,7 @@ public class CsvGuessableParserPlugin
                                 }
                             }
 
+                            @Override
                             public void timestampColumn(Column column)
                             {
                                 String v = nextColumn();
@@ -275,6 +280,7 @@ public class CsvGuessableParserPlugin
                                 }
                             }
 
+                            @Override
                             public void jsonColumn(Column column)
                             {
                                 String v = nextColumn();

--- a/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
@@ -2,19 +2,10 @@ package org.embulk.parser.csv_guessable;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
-import java.io.BufferedReader;
 import com.opencsv.CSVReader; // TODO: use embulk's parser
-import java.io.IOException;
-import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import org.slf4j.Logger;
 
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
-import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
@@ -25,21 +16,30 @@ import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.DataException;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileInput;
-import org.embulk.spi.json.JsonParser;
-import org.embulk.spi.json.JsonParseException;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.PageOutput;
 import org.embulk.spi.ParserPlugin;
 import org.embulk.spi.Schema;
 import org.embulk.spi.SchemaConfig;
-import org.embulk.spi.time.TimestampParser;
+import org.embulk.spi.json.JsonParseException;
+import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.time.TimestampParseException;
+import org.embulk.spi.time.TimestampParser;
 import org.embulk.spi.type.Types;
 import org.embulk.spi.unit.LocalFile;
 import org.embulk.spi.util.LineDecoder;
 import org.embulk.spi.util.Timestamps;
-
 import org.embulk.standards.CsvParserPlugin;
+
+import org.slf4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 
 public class CsvGuessableParserPlugin
         extends CsvParserPlugin

--- a/src/main/java/org/embulk/parser/csv_guessable/CsvTokenizer.java
+++ b/src/main/java/org/embulk/parser/csv_guessable/CsvTokenizer.java
@@ -1,13 +1,14 @@
 package org.embulk.parser.csv_guessable;
 
 import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.ArrayDeque;
+import org.embulk.config.ConfigException;
 import org.embulk.spi.DataException;
 import org.embulk.spi.util.LineDecoder;
-import org.embulk.config.ConfigException;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
 
 public class CsvTokenizer
 {

--- a/src/main/java/org/embulk/parser/csv_guessable/CsvTokenizer.java
+++ b/src/main/java/org/embulk/parser/csv_guessable/CsvTokenizer.java
@@ -50,11 +50,13 @@ public class CsvTokenizer
         String delimiter = task.getDelimiter();
         if (delimiter.length() == 0) {
             throw new ConfigException("Empty delimiter is not allowed");
-        } else {
+        }
+        else {
             this.delimiterChar = delimiter.charAt(0);
             if (delimiter.length() > 1) {
                 delimiterFollowingString = delimiter.substring(1);
-            } else {
+            }
+            else {
                 delimiterFollowingString = null;
             }
         }
@@ -88,7 +90,8 @@ public class CsvTokenizer
         String skippedLine;
         if (quotedValueLines.isEmpty()) {
             skippedLine = line;
-        } else {
+        }
+        else {
             // recover lines of quoted value
             skippedLine = quotedValueLines.remove(0);  // TODO optimize performance
             unreadLines.addAll(quotedValueLines);
@@ -129,7 +132,8 @@ public class CsvTokenizer
         if (hasNext) {
             recordState = RecordState.NOT_END;
             return true;
-        } else {
+        }
+        else {
             return false;
         }
     }
@@ -139,7 +143,8 @@ public class CsvTokenizer
         while (true) {
             if (!unreadLines.isEmpty()) {
                 line = unreadLines.removeFirst();
-            } else {
+            }
+            else {
                 line = input.poll();
                 if (line == null) {
                     return false;
@@ -189,7 +194,8 @@ public class CsvTokenizer
                         // empty value
                         if (delimiterFollowingString == null) {
                             return "";
-                        } else if (isDelimiterFollowingFrom(linePos)) {
+                        }
+                        else if (isDelimiterFollowingFrom(linePos)) {
                             linePos += delimiterFollowingString.length();
                             return "";
                         }
@@ -199,17 +205,17 @@ public class CsvTokenizer
                         // empty value
                         recordState = RecordState.END;
                         return "";
-
-                    } else if (isSpace(c) && trimIfNotQuoted) {
+                    }
+                    else if (isSpace(c) && trimIfNotQuoted) {
                         columnState = ColumnState.FIRST_TRIM;
-
-                    } else if (isQuote(c)) {
+                    }
+                    else if (isQuote(c)) {
                         valueStartPos = linePos;  // == 1
                         wasQuotedColumn = true;
                         quotedValue = new StringBuilder();
                         columnState = ColumnState.QUOTED_VALUE;
-
-                    } else {
+                    }
+                    else {
                         columnState = ColumnState.VALUE;
                     }
                     break;
@@ -219,7 +225,8 @@ public class CsvTokenizer
                         // empty value
                         if (delimiterFollowingString == null) {
                             return "";
-                        } else if (isDelimiterFollowingFrom(linePos)) {
+                        }
+                        else if (isDelimiterFollowingFrom(linePos)) {
                             linePos += delimiterFollowingString.length();
                             return "";
                         }
@@ -229,18 +236,18 @@ public class CsvTokenizer
                         // empty value
                         recordState = RecordState.END;
                         return "";
-
-                    } else if (isQuote(c)) {
+                    }
+                    else if (isQuote(c)) {
                         // column has heading spaces and quoted. TODO should this be rejected?
                         valueStartPos = linePos;
                         wasQuotedColumn = true;
                         quotedValue = new StringBuilder();
                         columnState = ColumnState.QUOTED_VALUE;
-
-                    } else if (isSpace(c)) {
+                    }
+                    else if (isSpace(c)) {
                         // skip this character
-
-                    } else {
+                    }
+                    else {
                         valueStartPos = linePos - 1;
                         columnState = ColumnState.VALUE;
                     }
@@ -250,7 +257,8 @@ public class CsvTokenizer
                     if (isDelimiter(c)) {
                         if (delimiterFollowingString == null) {
                             return line.substring(valueStartPos, linePos - 1);
-                        } else if (isDelimiterFollowingFrom(linePos)) {
+                        }
+                        else if (isDelimiterFollowingFrom(linePos)) {
                             String value = line.substring(valueStartPos, linePos - 1);
                             linePos += delimiterFollowingString.length();
                             return value;
@@ -260,8 +268,8 @@ public class CsvTokenizer
                     if (isEndOfLine(c)) {
                         recordState = RecordState.END;
                         return line.substring(valueStartPos, linePos);
-
-                    } else if (isSpace(c) && trimIfNotQuoted) {
+                    }
+                    else if (isSpace(c) && trimIfNotQuoted) {
                         valueEndPos = linePos - 1;  // this is possibly end of value
                         columnState = ColumnState.LAST_TRIM_OR_VALUE;
 
@@ -270,8 +278,8 @@ public class CsvTokenizer
                     //    // In RFC4180, If fields are not enclosed with double quotes, then
                     //    // double quotes may not appear inside the fields. But they are often
                     //    // included in the fields. We should care about them later.
-
-                    } else {
+                    }
+                    else {
                         // keep VALUE state
                     }
                     break;
@@ -280,21 +288,23 @@ public class CsvTokenizer
                     if (isDelimiter(c)) {
                         if (delimiterFollowingString == null) {
                             return line.substring(valueStartPos, valueEndPos);
-                        } else if (isDelimiterFollowingFrom(linePos)) {
+                        }
+                        else if (isDelimiterFollowingFrom(linePos)) {
                             linePos += delimiterFollowingString.length();
                             return line.substring(valueStartPos, valueEndPos);
-                        } else {
+                        }
+                        else {
                             // not a delimiter
                         }
                     }
                     if (isEndOfLine(c)) {
                         recordState = RecordState.END;
                         return line.substring(valueStartPos, valueEndPos);
-
-                    } else if (isSpace(c)) {
+                    }
+                    else if (isSpace(c)) {
                         // keep LAST_TRIM_OR_VALUE state
-
-                    } else {
+                    }
+                    else {
                         // this spaces are not trailing spaces. go back to VALUE state
                         columnState = ColumnState.VALUE;
                     }
@@ -310,18 +320,19 @@ public class CsvTokenizer
                             throw new InvalidValueException("Unexpected end of line during parsing a quoted value");
                         }
                         valueStartPos = 0;
-
-                    } else if (isQuote(c)) {
+                    }
+                    else if (isQuote(c)) {
                         char next = peekNextChar();
                         if (isQuote(next)) { // escaped quote
                             quotedValue.append(line.substring(valueStartPos, linePos));
                             valueStartPos = ++linePos;
-                        } else {
+                        }
+                        else {
                             quotedValue.append(line.substring(valueStartPos, linePos - 1));
                             columnState = ColumnState.AFTER_QUOTED_VALUE;
                         }
-
-                    } else if (isEscape(c)) {  // isQuote must be checked first in case of quote == escape
+                    }
+                    else if (isEscape(c)) {  // isQuote must be checked first in case of quote == escape
                         // In RFC 4180, CSV's escape char is '\"'. But '\\' is often used.
                         char next = peekNextChar();
                         if (isEndOfLine(c)) {
@@ -332,15 +343,16 @@ public class CsvTokenizer
                                 throw new InvalidValueException("Unexpected end of line during parsing a quoted value");
                             }
                             valueStartPos = 0;
-                        } else if (isQuote(next) || isEscape(next)) { // escaped quote
+                        }
+                        else if (isQuote(next) || isEscape(next)) { // escaped quote
                             quotedValue.append(line.substring(valueStartPos, linePos - 1));
                             quotedValue.append(next);
                             valueStartPos = ++linePos;
                         }
-
-                    } else {
+                    }
+                    else {
                         if ((linePos - valueStartPos) + quotedValue.length() > maxQuotedSizeLimit) {
-                            throw new QuotedSizeLimitExceededException("The size of the quoted value exceeds the limit size ("+maxQuotedSizeLimit+")");
+                            throw new QuotedSizeLimitExceededException("The size of the quoted value exceeds the limit size (" + maxQuotedSizeLimit + ")");
                         }
                         // keep QUOTED_VALUE state
                     }
@@ -350,7 +362,8 @@ public class CsvTokenizer
                     if (isDelimiter(c)) {
                         if (delimiterFollowingString == null) {
                             return quotedValue.toString();
-                        } else if (isDelimiterFollowingFrom(linePos)) {
+                        }
+                        else if (isDelimiterFollowingFrom(linePos)) {
                             linePos += delimiterFollowingString.length();
                             return quotedValue.toString();
                         }
@@ -359,11 +372,11 @@ public class CsvTokenizer
                     if (isEndOfLine(c)) {
                         recordState = RecordState.END;
                         return quotedValue.toString();
-
-                    } else if (isSpace(c)) {
+                    }
+                    else if (isSpace(c)) {
                         // column has trailing spaces and quoted. TODO should this be rejected?
-
-                    } else {
+                    }
+                    else {
                         throw new InvalidValueException(String.format("Unexpected extra character '%c' after a value quoted by '%c'", c, quote));
                     }
                     break;
@@ -411,7 +424,8 @@ public class CsvTokenizer
 
         if (linePos >= line.length()) {
             return END_OF_LINE;
-        } else {
+        }
+        else {
             return line.charAt(linePos++);
         }
     }
@@ -422,7 +436,8 @@ public class CsvTokenizer
 
         if (linePos >= line.length()) {
             return END_OF_LINE;
-        } else {
+        }
+        else {
             return line.charAt(linePos);
         }
     }

--- a/src/test/java/org/embulk/parser/csv_guessable/TestCsvGuessableParserPlugin.java
+++ b/src/test/java/org/embulk/parser/csv_guessable/TestCsvGuessableParserPlugin.java
@@ -1,17 +1,16 @@
 package org.embulk.parser.csv_guessable;
 
+import org.embulk.EmbulkTestRuntime;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigLoader;
 import org.embulk.config.ConfigSource;
-import org.embulk.EmbulkTestRuntime;
 import org.embulk.spi.Exec;
 import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
+import org.junit.rules.ExpectedException;
 
 import static org.embulk.parser.csv_guessable.CsvGuessableParserPlugin.PluginTask;
+import static org.junit.Assert.assertFalse;
 
 public class TestCsvGuessableParserPlugin
 {


### PR DESCRIPTION
I changed followings that were warned by `./gradlew checkstyle` command.
* Fix code format
* Fix import order

And I added `@Override` annotation to some methods.

Please ignore you don't prefer these changes.