### PR TITLE
ヘッダのパース時のseparatorをdelimiterと同じものにする

### DIFF
--- a/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
@@ -403,7 +403,7 @@ public class CsvGuessableParserPlugin
         ArrayList<ColumnConfig> columns = new ArrayList<ColumnConfig>();
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        try (CSVReader reader = new CSVReader(new StringReader(header), delimiter.toCharArray()[0])) {
+        try (CSVReader reader = new CSVReader(new StringReader(header), delimiter.charAt(0))) {
             String[] csv = reader.readNext();
             for (String column : csv) {
                 columns.add(new ColumnConfig(column, Types.STRING, config));

--- a/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
+++ b/src/main/java/org/embulk/parser/csv_guessable/CsvGuessableParserPlugin.java
@@ -141,7 +141,9 @@ public class CsvGuessableParserPlugin
 
             String header = readHeader(task.getSchemaFile().get().getPath(), schemaLine, task.getCharset());
             log.debug(header);
-            ArrayList<ColumnConfig> schema = newColumns(header, config);
+            String delimiter = task.getDelimiter();
+            ArrayList<ColumnConfig> schema = newColumns(header, config, delimiter);
+
 
             /* alias and set type */
             if (task.getSchemaConfig().isPresent()) {
@@ -396,12 +398,12 @@ public class CsvGuessableParserPlugin
         return line;
     }
 
-    private ArrayList<ColumnConfig> newColumns(String header, ConfigSource config)
+    private ArrayList<ColumnConfig> newColumns(String header, ConfigSource config, String delimiter)
     {
         ArrayList<ColumnConfig> columns = new ArrayList<ColumnConfig>();
         PluginTask task = config.loadConfig(PluginTask.class);
 
-        try (CSVReader reader = new CSVReader(new StringReader(header))) {
+        try (CSVReader reader = new CSVReader(new StringReader(header), delimiter.toCharArray()[0])) {
             String[] csv = reader.readNext();
             for (String column : csv) {
                 columns.add(new ColumnConfig(column, Types.STRING, config));

--- a/src/test/java/org/embulk/parser/csv_guessable/TestCsvGuessableParserPlugin.java
+++ b/src/test/java/org/embulk/parser/csv_guessable/TestCsvGuessableParserPlugin.java
@@ -121,6 +121,35 @@ public class TestCsvGuessableParserPlugin
     }
 
     @Test
+    public void guessableTsv()
+            throws Exception
+    {
+        String configYaml = "" +
+                "type: csv_guessable\n" +
+                "schema_file: src/test/resources/org/embulk/parser/csv_guessable/data/test.tsv\n" + // TODO: FIX PATH
+                "schema_line: 1\n" +
+                "delimiter: \"\\t\"";
+        ConfigSource config = getConfigFromYaml(configYaml);
+        transaction(config, fileInput("data/test.tsv"));
+        List<Object[]> records = Pages.toObjects(schema, output.pages);
+        assertEquals(2, records.size());
+
+        Object[] record;
+        {
+            record = records.get(0);
+            assertEquals("100", record[0]);
+            assertEquals("test-title", record[1]);
+            assertEquals("ok", record[2]);
+        }
+        {
+            record = records.get(1);
+            assertEquals("191", record[0]);
+            assertEquals("title2", record[1]);
+            assertEquals("ng", record[2]);
+        }
+    }
+
+    @Test
     public void specifyType()
             throws Exception
     {

--- a/src/test/resources/org/embulk/parser/csv_guessable/data/test.tsv
+++ b/src/test/resources/org/embulk/parser/csv_guessable/data/test.tsv
@@ -1,0 +1,3 @@
+"id"	"title"	"status"
+"100"	"test-title"	"ok"
+"191"	"title2"	"ng"


### PR DESCRIPTION
ヘッダのパース時にCSVReaderに渡すseparatorをdelimiterに指定したものと同じになるようにしました。

TSVファイルのパースしようとした時、ヘッダのパースに使っているCSVReaderのseparatorがデフォルトの `,` を使っていたため、tab区切りのTSVヘッダが失敗してしまったので、delimiterに設定したものを使うようにしました。

よろしくお願いします。